### PR TITLE
fix: no need to handle unchaughtexception

### DIFF
--- a/lib/node-nailgun-server.js
+++ b/lib/node-nailgun-server.js
@@ -53,11 +53,6 @@ module.exports.createServer = function (options, callback) {
 
   process.on('exit', shutdown)
 
-  process.on('uncaughtException', function (err) {
-    shutdown()
-    throw err
-  })
-
   return {
     out: server.stdout,
     shutdown: shutdown


### PR DESCRIPTION
It will break developer's code because any error thrown in `uncaughtException` handler won't emit `uncaughtException ` again. Listen `exit` event to shutdown the server is already enough.